### PR TITLE
refactor: consolidate skill data into single source of truth

### DIFF
--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,11 +1,12 @@
 import { MDBTypography } from "mdb-react-ui-kit"
 
-import { skillCategories, getImage } from "../utils/tech-icons"
+import { skillCategories } from "../constants/appData"
+import { getImage } from "../utils/tech-icons"
 
 import type { SectionProps } from "../types/types"
 
 function Skills({ id }: SectionProps) {
-  const categories = skillCategories()
+  const categories = skillCategories
 
   return (
     <div id={id} data-testid={id}>

--- a/src/constants/appData.ts
+++ b/src/constants/appData.ts
@@ -1,4 +1,4 @@
-import { BadgeConfig } from "../types/types"
+import { BadgeConfig, Skill, SkillCategories } from "../types/types"
 
 // Developer console message
 export const DEV_MESSAGE = {
@@ -43,22 +43,38 @@ export const footerLinks = [
 export const DEVICON_BASE_URL =
   "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons"
 
-// Image source mapping
-export const iconSources: Record<string, string> = {
-  gitlab: `${DEVICON_BASE_URL}/gitlab/gitlab-original.svg`,
-  bitbucket: `${DEVICON_BASE_URL}/bitbucket/bitbucket-original.svg`,
-  github: `${DEVICON_BASE_URL}/github/github-original.svg`,
-  browserstack: `${DEVICON_BASE_URL}/browserstack/browserstack-original.svg`,
-  playwright: `${DEVICON_BASE_URL}/playwright/playwright-original.svg`,
-  vim: `${DEVICON_BASE_URL}/vim/vim-original.svg`,
-  javascript: `${DEVICON_BASE_URL}/javascript/javascript-original.svg`,
-  typescript: `${DEVICON_BASE_URL}/typescript/typescript-original.svg`,
-  vscode: `${DEVICON_BASE_URL}/vscode/vscode-original.svg`,
-  ember: `${DEVICON_BASE_URL}/ember/ember-original.svg`,
-  html: `${DEVICON_BASE_URL}/html5/html5-original-wordmark.svg`,
-  css: `${DEVICON_BASE_URL}/css3/css3-original-wordmark.svg`,
-  cypress: `${DEVICON_BASE_URL}/cypressio/cypressio-original.svg`,
-  react: `${DEVICON_BASE_URL}/react/react-original.svg`,
-  webpack: `${DEVICON_BASE_URL}/webpack/webpack-original.svg`,
-  "tricentis-qtest": `${DEVICON_BASE_URL}/qtest/qtest-original.svg`,
+export const skillCategories: SkillCategories = {
+  "Test Automation & QA": {
+    icon: "🧪",
+    skills: [
+      { name: "cypress", years: "2+", isCore: true, iconPath: "cypressio/cypressio-original.svg" },
+      { name: "playwright", years: "1+", isCore: true, iconPath: "playwright/playwright-original.svg" },
+      { name: "testing-library", years: "2+", isCore: true, customImageKey: "testing-library" },
+      { name: "tricentis-qtest", years: "3+", isCore: false, iconPath: "qtest/qtest-original.svg" },
+      { name: "browserstack", years: "2+", isCore: false, iconPath: "browserstack/browserstack-original.svg" },
+    ] as Skill[],
+  },
+  "Frontend Development": {
+    icon: "🎨",
+    skills: [
+      { name: "typeScript", years: "4+", isCore: true, iconPath: "typescript/typescript-original.svg" },
+      { name: "javaScript", years: "8+", isCore: true, iconPath: "javascript/javascript-original.svg" },
+      { name: "react", years: "6+", isCore: true, iconPath: "react/react-original.svg" },
+      { name: "ember", years: "3", isCore: false, iconPath: "ember/ember-original.svg" },
+      { name: "html", years: "8+", isCore: false, iconPath: "html5/html5-original-wordmark.svg" },
+      { name: "css", years: "8+", isCore: false, iconPath: "css3/css3-original-wordmark.svg" },
+      { name: "styled-components", years: "3+", isCore: false, customImageKey: "styled-components" },
+    ] as Skill[],
+  },
+  "Development Tools & CI/CD": {
+    icon: "🔧",
+    skills: [
+      { name: "github", years: "8+", isCore: false, iconPath: "github/github-original.svg" },
+      { name: "gitlab", years: "3+", isCore: false, iconPath: "gitlab/gitlab-original.svg" },
+      { name: "bitbucket", years: "3+", isCore: false, iconPath: "bitbucket/bitbucket-original.svg" },
+      { name: "vscode", years: "6+", isCore: false, iconPath: "vscode/vscode-original.svg" },
+      { name: "webpack", years: "4", isCore: false, iconPath: "webpack/webpack-original.svg" },
+      { name: "vim", years: "3+", isCore: false, iconPath: "vim/vim-original.svg" },
+    ] as Skill[],
+  },
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -3,9 +3,6 @@ export interface BadgeConfig {
   text: string
 }
 
-export interface CustomImageMap {
-  readonly [key: string]: JSX.Element
-}
 
 export interface FooterLink {
   href: string
@@ -17,13 +14,6 @@ export interface FooterLinksProps {
   links: readonly FooterLink[]
 }
 
-export interface GetImageProps {
-  readonly name: string
-  readonly years: string
-  readonly imageSrc?: string
-  readonly customImage?: JSX.Element
-  readonly isCore?: boolean
-}
 
 export interface Project {
   title: string
@@ -46,8 +36,8 @@ export interface Skill {
   name: string
   years: string
   isCore: boolean
-  imageSrc?: string
-  customImage?: JSX.Element
+  iconPath?: string
+  customImageKey?: string
 }
 
 export interface SkillCategory {

--- a/src/utils/tech-icons.tsx
+++ b/src/utils/tech-icons.tsx
@@ -2,18 +2,13 @@ import { MDBContainer } from "mdb-react-ui-kit"
 
 import TestingLib from "../assets/img/octopus.png"
 import StyledComp from "../assets/img/styled-components.png"
-import { iconSources } from "../constants/appData"
+import { DEVICON_BASE_URL } from "../constants/appData"
 
 import { capitalizeFirstLetter } from "./utils"
 
-import type {
-  CustomImageMap,
-  GetImageProps,
-  SkillCategories,
-} from "../types/types"
+import type { Skill } from "../types/types"
 
-// Custom images for tools without devicon support
-const customImages: CustomImageMap = {
+const customImages: Record<string, JSX.Element> = {
   "styled-components": (
     <img src={StyledComp} alt="styled-components" width={60} height={60} />
   ),
@@ -22,141 +17,10 @@ const customImages: CustomImageMap = {
   ),
 }
 
-// Categorized skills with core skills marked
-export function skillCategories(): SkillCategories {
-  return {
-    "Test Automation & QA": {
-      icon: "🧪",
-      skills: [
-        {
-          name: "cypress",
-          years: "2+",
-          isCore: true,
-          imageSrc: iconSources.cypress,
-        },
-        {
-          name: "playwright",
-          years: "1+",
-          isCore: true,
-          imageSrc: iconSources.playwright,
-        },
-        {
-          name: "testing-library",
-          years: "2+",
-          isCore: true,
-          customImage: customImages["testing-library"],
-        },
-        {
-          name: "tricentis-qtest",
-          years: "3+",
-          isCore: false,
-          imageSrc: iconSources["tricentis-qtest"],
-        },
-        {
-          name: "browserstack",
-          years: "2+",
-          isCore: false,
-          imageSrc: iconSources.browserstack,
-        },
-      ],
-    },
-    "Frontend Development": {
-      icon: "🎨",
-      skills: [
-        {
-          name: "typeScript",
-          years: "4+",
-          isCore: true,
-          imageSrc: iconSources.typescript,
-        },
-        {
-          name: "javaScript",
-          years: "8+",
-          isCore: true,
-          imageSrc: iconSources.javascript,
-        },
-        {
-          name: "react",
-          years: "6+",
-          isCore: true,
-          imageSrc: iconSources.react,
-        },
-        {
-          name: "ember",
-          years: "3",
-          isCore: false,
-          imageSrc: iconSources.ember,
-        },
-        {
-          name: "html",
-          years: "8+",
-          isCore: false,
-          imageSrc: iconSources.html,
-        },
-        { name: "css", years: "8+", isCore: false, imageSrc: iconSources.css },
-        {
-          name: "styled-components",
-          years: "3+",
-          isCore: false,
-          customImage: customImages["styled-components"],
-        },
-      ],
-    },
-    "Development Tools & CI/CD": {
-      icon: "🔧",
-      skills: [
-        {
-          name: "github",
-          years: "8+",
-          isCore: false,
-          imageSrc: iconSources.github,
-        },
-        {
-          name: "gitlab",
-          years: "3+",
-          isCore: false,
-          imageSrc: iconSources.gitlab,
-        },
-        {
-          name: "bitbucket",
-          years: "3+",
-          isCore: false,
-          imageSrc: iconSources.bitbucket,
-        },
-        {
-          name: "vscode",
-          years: "6+",
-          isCore: false,
-          imageSrc: iconSources.vscode,
-        },
-        {
-          name: "webpack",
-          years: "4",
-          isCore: false,
-          imageSrc: iconSources.webpack,
-        },
-        { name: "vim", years: "3+", isCore: false, imageSrc: iconSources.vim },
-      ],
-    },
-  }
-}
-
-/**
- * Renders a skill icon with its name and years of experience.
- * @param name - Skill name
- * @param imageSrc - URL to skill icon
- * @param customImage - Custom JSX image element (if no imageSrc)
- * @param isCore - Whether this is a core skill (TBD renders larger)
- */
-export function getImage({
-  name,
-  years,
-  imageSrc,
-  customImage,
-  isCore = false,
-}: GetImageProps): JSX.Element {
+export function getImage({ name, years, iconPath, customImageKey, isCore = false }: Skill): JSX.Element {
   const displayName = capitalizeFirstLetter(name)
-  const size = isCore ? 50 : 50
+  const imageSrc = iconPath != null ? `${DEVICON_BASE_URL}/${iconPath}` : undefined
+  const customImage = customImageKey != null ? customImages[customImageKey] : undefined
 
   return (
     <MDBContainer
@@ -164,13 +28,7 @@ export function getImage({
       className={`skill-item rounded-8 py-3 ${isCore ? "skill-item-core" : ""}`}
     >
       {imageSrc != null ? (
-        <img
-          src={imageSrc}
-          alt={name}
-          height={size}
-          width={size}
-          loading="lazy"
-        />
+        <img src={imageSrc} alt={name} height={50} width={50} loading="lazy" />
       ) : (
         customImage
       )}


### PR DESCRIPTION
Move skillCategories const to appData.ts and replace the separate iconSources lookup with inline iconPath/customImageKey per skill. Adding a new skill now requires editing one object in one file. Also removes dead size variable and redundant GetImageProps type.